### PR TITLE
Fix for unix directory paths

### DIFF
--- a/Editor/RCRenderPipeline.cs
+++ b/Editor/RCRenderPipeline.cs
@@ -134,7 +134,7 @@ namespace RealCode
 				directory = directory.Parent;
 
 			///Debug.Log(directory.FullName);
-			File.WriteAllText(directory.FullName + "\\" + CS_FILENAME, Code);
+			File.WriteAllText(directory.FullName + Path.DirectorySeparatorChar + CS_FILENAME, Code);
 
 		}
 		private static string CSharpFileCode (bool defineHDRP, bool defineURP)


### PR DESCRIPTION
Hi, the original string path seperator breaks the processing routines and leaves the editor in an infinite loop. Using the system's directory seperator fixes it. Tested this on Mac (2020.3.22f) and is now working fine.